### PR TITLE
Pon la comita xD

### DIFF
--- a/speed-run.txt
+++ b/speed-run.txt
@@ -64,7 +64,7 @@ systemctl restart httpd
 wwinit database
 wwinit ssh_keys
 
-(Hint: Remove .ssh/config all IdentityFiles but cluster or pdsh may complain after)
+(Hint: Remove .ssh/config all IdentityFiles butspeed-run.txt cluster, or pdsh may complain after)
 
 
 #Create exports to the nodes


### PR DESCRIPTION
(Hint: Remove .ssh/config all IdentityFiles or pdsh may complain after) 
Yo pondría una coma después de cluster porque confunde: (Hint: Remove .ssh/config all IdentityFiles butspeed-run.txt cluster, or pdsh may complain after)